### PR TITLE
Updated Pytorch, Tensorflow and GCC module pages

### DIFF
--- a/docs/hpc/applications/guides/GCC.md
+++ b/docs/hpc/applications/guides/GCC.md
@@ -1,0 +1,96 @@
+# GCC Compiler Module
+
+This page is a small guide on what type of modules to be used for compiling your programs with the GCC compiler. We are creating this page because of the way our module are built.
+
+If you use the incorrect module, you may get strange errors. Please see the example below which illustrates the same.
+
+Let us consider that we have the following `HelloWorld.cpp` program:
+
+```cpp
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello" << std::endl;
+    return 0;
+}
+```
+
+To compile the program, we need to load the GCC compilers first. To load them, we first load the `tool/prod` as shown below:
+
+```bash
+module load tools/prod
+
+# Then search for all GCC modules by
+module avail -i GCC
+```
+
+The above command will give you output like below:
+
+```bash
+------------------------------ /sw-eb/modules/all ------------------------------
+GCC/8.3.0   GCC/11.2.0  GCC/13.2.0      GCCcore/10.3.0  GCCcore/12.3.0  
+GCC/9.3.0   GCC/11.3.0  GCCcore/8.3.0   GCCcore/11.2.0  GCCcore/13.2.0  
+GCC/10.2.0  GCC/12.2.0  GCCcore/9.3.0   GCCcore/11.3.0  gcccuda/2020a   
+GCC/10.3.0  GCC/12.3.0  GCCcore/10.2.0  GCCcore/12.2.0  
+
+----------------------- /apps/modules/4.7.1/modulefiles ------------------------
+gcc-xml/2013-01-04  gcc/4.9.1                      gcc/6.2.0  gcc/10.2.0  
+gcc/4.7.2           gcc/5.4.0(default)             gcc/8.2.0  gcc/11.2.0  
+gcc/4.7.4           gcc/5.4.0-disable-linux-futex  gcc/9.3.0
+```
+
+For performance reasons, we recommend using the modules under the `/sw-eb/modules/all` directory. 
+
+Someone may decide to use modules like `GCCcore/12.3.0` i.e. the one which has the word core in it. Let us go ahead and compile our program.
+
+```bash
+# Load the module
+module load GCCcore/12.3.0
+
+# Compile the program
+g++ -o HelloWorld HelloWorld.cpp
+```
+
+You will get errors like
+
+```bash
+/usr/bin/ld: /rds/easybuild/zen2/apps/software/GCCcore/12.3.0/bin/../lib/gcc/x86_64-pc-linux-gnu/12.3.0/libgcc.a(_muldi3.o): unable to initialize decompress status for section .debug_info
+```
+
+This is because the core modules do not load the `binutils` module which is required for the GCC compiler to work correctly. To see this, if you type the following
+
+```bash
+# See all loaded modules
+module list
+
+# You will see the output
+Currently Loaded Modulefiles:
+ 1) tools/prod   2) GCCcore/12.3.0 
+```
+
+Now, let us use the correct GCC module and compile the program.
+
+```bash
+# First unload the current modules
+module purge
+
+# Then load the tools/prod and necessary GCC module
+module load tools/prod
+module load GCC/12.3.0
+
+# Compile the program
+g++ -o HelloWorld HelloWorld.cpp
+```
+
+This time the program will compile without any errors.
+
+If you see the list of modules loaded, you will see the following:
+
+```bash
+Currently Loaded Modulefiles:
+ 1) tools/prod            3) zlib/1.2.13-GCCcore-12.3.0 <aL>    
+ 2) GCCcore/12.3.0 <aL>   4) binutils/2.40-GCCcore-12.3.0 <aL>
+```
+
+As you can see from the output, the `binutils` module is loaded which is required for the GCC compiler to work correctly.

--- a/docs/hpc/applications/guides/pytorch.md
+++ b/docs/hpc/applications/guides/pytorch.md
@@ -5,7 +5,7 @@
 ## Conda
 Whether using  CPU's or GPU's, you should install PyTorch into a clean Anaconda environment. You will need to first setup up your own [Anaconda environment](./conda.md).
 
-Please take care when installing PyTorch with other packages. It isn't uncommon for PyTorch to conflict with other packages so we generally recommend keeping your PyTorch environment to a minimum.
+Please take care when installing PyTorch with other packages. It isn't uncommon for PyTorch to conflict with other packages so we generally recommend keeping your PyTorch environment to a minimum. Also, for users who are interested to have both the Pytorch and TensorFlow installed in the same environment, please replace the last line in the code block  with the one provided in the TensorFlow and Pytorch section.
 
 ```console
 module load anaconda3/personal
@@ -17,10 +17,22 @@ mkdir -p $CONDA_PREFIX/etc/conda/activate.d
 echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
 echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
 source $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+
+# For both TensorFlow and Pytorch, use the command in the next section.
 python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 ```
 
-You should then be able to set this works in a job, for example
+## TensorFlow and Pytorch
+
+Please make sure that you have run all the commands (except the last one as mentioned in the comments) from the above section before running the following command.
+
+```bash
+python3 -m pip install torch torchvision torchaudio tensorflow==2.12.*
+```
+
+## Check Pytorch Installation
+
+You should then be able to set this work in a job, for example
 
 ```bash
 #!/bin/bash
@@ -35,3 +47,5 @@ source activate  pytorch_env
 ## Verify install:
 python -c "import torch;print(torch.cuda.is_available())"
 ```
+
+To check your  tensorflow installation in this environment, please see the section on [TensorFlow](./tensorflow.md).

--- a/docs/hpc/applications/guides/pytorch.md
+++ b/docs/hpc/applications/guides/pytorch.md
@@ -5,7 +5,7 @@
 ## Conda
 Whether using  CPU's or GPU's, you should install PyTorch into a clean Anaconda environment. You will need to first setup up your own [Anaconda environment](./conda.md).
 
-Please take care when installing PyTorch with other packages. It isn't uncommon for PyTorch to conflict with other packages so we generally recommend keeping your PyTorch environment to a minimum. Also, for users who are interested to have both the Pytorch and TensorFlow installed in the same environment, please replace the last line in the code block  with the one provided in the TensorFlow and Pytorch section.
+Please take care when installing PyTorch with other packages. It isn't uncommon for PyTorch to conflict with other packages so we generally recommend keeping your PyTorch environment to a minimum. Also, for users who are interested in having both Pytorch and TensorFlow installed in the same environment, please replace the last line in the code block with the one provided in the TensorFlow and Pytorch section.
 
 ```console
 module load anaconda3/personal
@@ -32,7 +32,7 @@ python3 -m pip install torch torchvision torchaudio tensorflow==2.12.*
 
 ## Check Pytorch Installation
 
-You should then be able to set this work in a job, for example
+You should then be able to test this works in a job, for example:
 
 ```bash
 #!/bin/bash

--- a/docs/hpc/applications/guides/tensorflow.md
+++ b/docs/hpc/applications/guides/tensorflow.md
@@ -66,6 +66,8 @@ source $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
 python3 -m pip install tensorflow==2.12.*
 ```
 
+## Check TensorFlow Installation
+
 Once the installation has been completed a test job can be submitted to PBS.
 
 ```bash

--- a/docs/hpc/applications/guides/tensorflow.md
+++ b/docs/hpc/applications/guides/tensorflow.md
@@ -48,7 +48,9 @@ This will display all the currently installed versions of Tensorflow.
 ## Conda
 Whether using  CPU's or GPU's, you should install TensorFlow into a clean Anaconda environment. You will need to first setup up your own [Anaconda environment](./conda.md).
 
-Please take care when installing Tensorflow with other packages. It isn't uncommon for Tensorflow to conflict with other packages so we generally recommend keeping your Tensorflow environment to a minimum.
+Please take care when installing Tensorflow with other packages. It isn't uncommon for Tensorflow to conflict with other packages so we generally recommend keeping your Tensorflow environment to a minimum. 
+
+If you want to have both Pytorch and Tensorflow in your single environment, please follow the section on [PyTorch](./pytorch.md/#tensorflow-and-pytorch)
 
 The example below installs both the CPU and GPU version of Tensorflow. If you don't need/want to use a GPU the you don't need to install Cudatoolkit or cudnn. This installation method is based on the advice at [https://www.tensorflow.org/install/pip](https://www.tensorflow.org/install/pip) You should be able to copy+paste the sets one-by-one. 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
         - Overview: hpc/applications/guides/index.md
         - Abaqus: hpc/applications/guides/abaqus.md
         - Conda: hpc/applications/guides/conda.md
+        - GCC: hpc/applications/guides/GCC.md
         - Jupyter: hpc/applications/guides/jupyter.md
         - Lumerical: hpc/applications/guides/lumerical.md
         - MATLAB: hpc/applications/guides/matlab.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,7 @@ nav:
       - Jobs causing issues with the RDS: hpc/faq/job-issues-rds.md
       - No such file or directory: hpc/faq/bad-interpreter.md
       - Same or Previous Code not working: hpc/faq/code-not-working.md
-    - Advanced Topics:
+    - Debugging and Profiling:
       - Overview: hpc/advanced/index.md
       - Thread Pinning: hpc/advanced/thread-pinning.md
       - Application Profiling:


### PR DESCRIPTION
This PR addresses two concerns

1. For users who want to have both tenorflow and pytorch in the same environment, I have added details on how to do that. This is because if we try to install one after another, it leads to errors. 

2. I have also added details about GCCcore module and what issues it causes if try to use it.