### PR TITLE
Random back quotes in text

### DIFF
--- a/docs/hpc/pilot/cx3-phase2.md
+++ b/docs/hpc/pilot/cx3-phase2.md
@@ -18,7 +18,6 @@ Access to CX3 Phase 2 is controlled in the same way that it is for the original 
     * 36 * AMD Rome with 2x AMD EPYC 7742 64-Core Processor (Rome); 128 cores per node; 1TB per node; 8 GB Ram per core.
 * GPU Nodes
     * 7 x Intel nodes, 2 x Intel Xeon Platinum 8358 (Ice Lake) 2.60GHz 32-core processors; 64 cores per node; 1 TB RAM, 8 x [L40S](https://www.nvidia.com/en-us/data-center/l40s/) 48GB GDDR6 GPUs per node.
-```
     * 2 x Intel nodes, 2 x Intel Xeon Platinum 8358 (Ice Lake) 2.60GHz 32-core processors; 64 cores per node; 1 TB RAM, 2 x [A100](https://www.nvidia.com/en-gb/data-center/a100/) 40GB GDDR6 GPUs per node.
     * 1 x Intel node, with 2 x Intel Xeon Platinum 8358 (Ice Lake) 2.60GHz 32-core processors; 64 cores per node; 1 TB RAM, 4 x [A40](https://www.nvidia.com/en-gb/data-center/a40/) 48GB GDDR6 GPUs per node.
 


### PR DESCRIPTION
Removed the back quotes in the middle of the cluster specification