### PR TITLE
Added workshop overview page

### DIFF
--- a/docs/Workshops/overview.md
+++ b/docs/Workshops/overview.md
@@ -1,0 +1,15 @@
+# Overview
+
+Research Computing Service (RCS) team at Imperial is trying to collaborate with Industrial partners/vendors to provide some training and workshops for the Imperial College community.
+
+We will be adding information about our upcoming workshops here. We kindly ask the users to explore this section and register for the workshops they are interested in.
+
+Click below for the relevant workshops:
+
+* [Intel One Api Workshops](./Intel/overview.md)
+
+* [NVIDIA Workshops](./Nvidia/overview.md)
+
+We will also send out information about these workshops via our Newsletter. If you are not subscribed to our newsletter, please [subscribe to the RCS newsletter](https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/about/newsletter-subscription/).
+
+Some of the workshops will be exclusive to **Imperial College members only**, and some will be open to the *public*. Please check the workshop details for more information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Disk Space: rds/managing/disk-space.md
       - Recovering Deleted Files: rds/managing/recovering-deleted-files.md
   - Workshops and Courses:
+    - Overview: Workshops/overview.md
     - Intel One Api Workshops:
       - Overview: Workshops/Intel/overview.md
       - Presenter: Workshops/Intel/presenter.md


### PR DESCRIPTION
In this PR, we add an overview page for the Workshops. This page can be used as a landing page whenever we share anything to users. 

At present, we have to point to either Intel page or Nvidia page which is not the best possible option.