### PR TITLE
Switch to conda-forge managing Python and R environments

### DIFF
--- a/docs/hpc/applications/guides/R.md
+++ b/docs/hpc/applications/guides/R.md
@@ -28,11 +28,11 @@ In order to use R on the login node, say for a quick testing, you can replace th
 
 Remember, that the login nodes are only there for pre- and post-processing of jobs, not for running extensive calculations, specially if they are heavy on the file system. If you need to run jobs interactively, please refer to the interactive job-requests to the queue.
 
-## Anaconda R
+## conda and R
 To begin, following the instructions in the [Conda application guide](./conda.md) to setup Conda for your account. Assuming you have done this, the following set of instructions would create an environment called r413 containing R version 4.1.3.
 
 ```console
-module load anaconda3/personal
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda create -n r413 r-base=4.1.3 -c conda-forge
 source activate r413
 ```

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -10,7 +10,7 @@ Using different conda environments for different projects/applications is highly
 
 
 ## Using conda
-If its the first time loading you will need to install miniforge. We have created a simple helper script which will install everything or update your installtion if you already have miniforce installed. To get started run the following on any login node:
+If its the first time loading you will need to install miniforge. We have created a simple helper script which will install everything or update your installtion if you already have miniforge installed. To get started run the following on any login node:
 
 ```
 module load miniforge/3

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -55,4 +55,4 @@ eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda activate /rds/general/user/username/home/anaconda3/envs/tf2_env
 ```
 
-If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchace a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)
+If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchase a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -48,7 +48,7 @@ For a full list of commands please see [conda commands](https://docs.conda.io/pr
 
 ## Anaconda3/personal
 
-Long term users will remember the anaconda3/personal module and the attached documentation. This method relied on packages provided by Anaconda Inc. but in 2020 they changed their terms of service requiring all companies with more than 200 employess buy a commercial license. As most workflows on HPC use the conda-forge repo anyway we are moving to using the open source product provided by the same team that manage those repos. Users can continue to use their original envirnments if they install miniforge but they will have to be activated using the full path. For example, if you installed [Tensorflow](./tensorflow.md) following the old documentation you can still activate that envornment with the following:
+Long term users will remember the anaconda3/personal module and the attached documentation. This method relied on packages provided by Anaconda Inc. but in 2020 they changed their terms of service requiring all companies with more than 200 employess buy a commercial license. As most workflows on HPC use the conda-forge repo anyway we are moving to using the open source product provided by the same team that manage those repos. Users can continue to use their original environments if they install miniforge but they will have to be activated using the full path. For example, if you installed [Tensorflow](./tensorflow.md) following the old documentation you can still activate that envornment with the following:
 
 ```
 eval "$(~/miniforge3/bin/conda shell.bash hook)"

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -25,7 +25,7 @@ eval "$(~/miniforge3/bin/conda shell.bash hook)"
 
 You should use this command any time you wish to load conda. This also loads [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) into your environment. Mamba is similar to conda but can be a lot quicker and is able to handle more complex installations. Which you use is mostly up to you and your workflow. 
 
-One last thing to note, we recommend creating a new envirnoment for each workflow and to never modify the base envirnoment as this can break the conda installation. The best way to prevent this is to disable the automatic loading of the base envirnment by running:
+One last thing to note, we recommend creating a new environment for each workflow and to never modify the base environment as this can break the conda installation. The best way to prevent this is to disable the automatic loading of the base environment by running:
 
 ```
 conda config --set auto_activate_base false

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -23,7 +23,7 @@ You only need to run this once for your user account to install miniforge into y
 eval "$(~/miniforge3/bin/conda shell.bash hook)"
 ```
 
-You should use this command any time you wish to load conda. This also loads [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) into your envirnmoment. Mamba is similar to conda but can be a lot quicker and is able to handle more complex installations. Which you use is mostly up to you and your workflow. 
+You should use this command any time you wish to load conda. This also loads [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) into your environment. Mamba is similar to conda but can be a lot quicker and is able to handle more complex installations. Which you use is mostly up to you and your workflow. 
 
 One last thing to note, we recommend creating a new envirnoment for each workflow and to never modify the base envirnoment as this can break the conda installation. The best way to prevent this is to disable the automatic loading of the base envirnment by running:
 

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -48,4 +48,11 @@ For a full list of commands please see [conda commands](https://docs.conda.io/pr
 
 ## Anaconda3/personal
 
-Long term users will remember the anaconda3/personal module and the attached documentation. This method relied on packages provided by Anaconda Inc. but in 2020 they changed their terms of service requiring all companies with more than 200 employess buy a commercial license. As most workflows on HPC use the conda-forge repo anyway we are moving to using the open source product provided by the same team that manage those repos. 
+Long term users will remember the anaconda3/personal module and the attached documentation. This method relied on packages provided by Anaconda Inc. but in 2020 they changed their terms of service requiring all companies with more than 200 employess buy a commercial license. As most workflows on HPC use the conda-forge repo anyway we are moving to using the open source product provided by the same team that manage those repos. Users can continue to use their original envirnments if they install miniforge but they will have to be activated using the full path. For example, if you installed [Tensorflow](./tensorflow.md) following the old documentation you can still activate that envornment with the following:
+
+```
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
+conda activate /rds/general/user/username/home/anaconda3/envs/tf2_env
+```
+
+If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchace a license for every user. More information on Anaconda's ToS can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -1,8 +1,6 @@
 # Conda
 
-[Conda](https://docs.conda.io/en/latest/) is a package, dependency and environment management system that is available via the Anaconda distribution. It is one of the ways for users to manage their own environments and supports a wide range of languages: Python, R, Ruby, Lua, Scala, Java, JavaScript, C/ C++, FORTRAN.
-
-Conda as a package manager helps you find and install packages. If you need a package that requires a different version of Python, you do not need to switch to a different environment manager, because conda is also an environment manager. With just a few commands, you can set up a totally separate environment to run that different version of Python, while continuing to run your usual version of Python in your normal environment.
+[Conda](https://docs.conda.io/en/latest/index.html) is a package, dependency and environment management system. There are a couple of different versions avaible but we recommend using [conda-forge](https://conda-forge.org/download/). It is one of the ways for users to manage their own environments and supports a wide range of languages: Python, R, Ruby, Lua, Scala, Java, JavaScript, C/ C++, FORTRAN.
 
 Using different conda environments for different projects/applications is highly recommended and certainly offers many advantages:
 
@@ -10,22 +8,28 @@ Using different conda environments for different projects/applications is highly
 * conda environments can track non-python dependencies; for example seamlessly managing dependencies and parallel versions of essential tools like LAPACK or OpenSSL
 * Rather than environments built on symlinks – which break the isolation of the virtualenv and can be flimsy at times for non-Python dependencies – conda-envs are true isolated environments within a single executable path.
 
-![Conda](img/conda.jpeg)
 
 ## Using conda
-On the login node run:
-
-```console
-module load anaconda3/personal
-```
-
-If its the first time loading you will need to run:
+If its the first time loading you will need to install miniforge. We have created a simple helper script which will install everything or update your installtion if you already have miniforce installed. To get started run the following on any login node:
 
 ```
-anaconda-setup
+module load miniforge/3
+miniforge-setup
 ```
 
-You only need to run `anaconda-setup` once for your user account but `module load anaconda3/personal` will need to be run everytime you want to use the Anaconda environment (including in jobs).
+You only need to run this once for your user account to install miniforge into your home directory. Once complete you can load conda,
+
+```
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
+```
+
+You should use this command any time you wish to load conda. This also loads [mamba](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html) into your envirnmoment. Mamba is similar to conda but can be a lot quicker and is able to handle more complex installations. Which you use is mostly up to you and your workflow. 
+
+One last thing to note, we recommend creating a new envirnoment for each workflow and to never modify the base envirnoment as this can break the conda installation. The best way to prevent this is to disable the automatic loading of the base envirnment by running:
+
+```
+conda config --set auto_activate_base false
+```
 
 ## Conda Table of Commands
 
@@ -40,4 +44,8 @@ You only need to run `anaconda-setup` once for your user account but `module loa
 | Install a package included in Anaconda | conda install PACKAGENAME |
 | Remove unused packages and caches | conda clean |
 
-For a full list of commands please look at the [conda cheet sheet](https://docs.conda.io/projects/conda/en/latest/_downloads/843d9e0198f2a193a3484886fa28163c/conda-cheatsheet.pdf) provided by Anaconda.
+For a full list of commands please see [conda commands](https://docs.conda.io/projects/conda/en/stable/commands/index.html) provided by Anaconda.
+
+## Anaconda3/personal
+
+Long term users will remember the anaconda3/personal module and the attached documentation. This method relied on packages provided by Anaconda Inc. but in 2020 they changed their terms of service requiring all companies with more than 200 employess buy a commercial license. As most workflows on HPC use the conda-forge repo anyway we are moving to using the open source product provided by the same team that manage those repos. 

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -55,4 +55,4 @@ eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda activate /rds/general/user/username/home/anaconda3/envs/tf2_env
 ```
 
-If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchace a license for every user. More information on Anaconda's ToS can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)
+If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchace a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)

--- a/docs/hpc/applications/guides/jupyter.md
+++ b/docs/hpc/applications/guides/jupyter.md
@@ -18,7 +18,7 @@ The recommended way to work with python and R packages is via conda. This also e
 
 ### Python
 
-More information on how to use Python with conda can be found in the Python application guide.
+More information on how to use Python with conda can be found in the [Python application guide](./python.md).
 
 To use custom python modules within a Jupyter lab session:
 

--- a/docs/hpc/applications/guides/jupyter.md
+++ b/docs/hpc/applications/guides/jupyter.md
@@ -12,20 +12,20 @@ You must be registered with the HPC service in order to use the JupyterHub servi
 
 ## Load custom Packages/Modules in JupyterHub
 
-Whilst the default kernels available in Jupyter, whether Python or R, offer a certain number of base packages, users normally want to use their own custom packages within their programs. The good news is that Jupyter integrates perfectly with anaconda and its package and environment management systems.
+Whilst the default kernels available in Jupyter, whether Python or R, offer a certain number of base packages, users normally want to use their own custom packages within their programs. The good news is that Jupyter integrates perfectly with conda and its package and environment management systems.
 
-The recommended way to work with python and R packages is via anaconda. This also enables users to create segregated environments for different projects. More information on how to use conda environments can be found [here](./conda.md).
+The recommended way to work with python and R packages is via conda. This also enables users to create segregated environments for different projects. More information on how to use conda environments can be found [here](./conda.md).
 
 ### Python
 
-More information on how to use Python with Anaconda can be found in the Python application guide.
+More information on how to use Python with conda can be found in the Python application guide.
 
 To use custom python modules within a Jupyter lab session:
 
 **On login node run**
 
 * Load module
-<br>`module load anaconda3/personal`
+<br>`eval "$(~/miniforge3/bin/conda shell.bash hook)"`
 * Setup a new conda environment for this project. I named this environment "test1" as an example. * Note that I specify a couple of starting packages to be installed: ipykernel and python with a specific version.<br>
 `conda create -n test1 python=3.9 ipykernel jupyter_client`
 * Activate the environment:<br>
@@ -52,7 +52,7 @@ To use custom R libraries within a Jupyter lab session:
 **On login node run:**
 
 * Load module:<br>
-`module load anaconda3/personal`
+`eval "$(~/miniforge3/bin/conda shell.bash hook)"`
 * Setup a new conda environment for this project. I named this environment "ir413" as an example. * Note that I specify a couple of starting packages to be installed: r-irkernel and R with a specific version.<br>
 `conda create -n ir413 r-base=4.1.3 r-irkernel jupyter_client -c conda-forge`
 * Activate the environment:<br>

--- a/docs/hpc/applications/guides/openondemand.md
+++ b/docs/hpc/applications/guides/openondemand.md
@@ -10,16 +10,17 @@ We recommend you setup a [Conda](./conda.md) environment when using RStudio; the
 
 ## Creating an Conda Environment
 
-We recommend you familiarise yourself with the use of Conda and R by going to the [R application page](./R.md). You will then need to prepare your Conda environment by first connecting to the login node using SSH (see the [Getting started](../../getting-started/index.md) guide for advice on doing this) and then install miniforge following the advice on [Conda](./conda.md). Once done you can start creating R environments for OOD.
+We recommend you familiarise yourself with the use of Conda and R by going to the [R application page](./R.md). You will then need to prepare your Conda environment by first connecting to the login node using SSH (see the [Getting started](../../getting-started/index.md) guide for advice on doing this).
 
-Here we load miniforge and then create an environment called "Renv" with R version 4.1.2:
+From there, load Anaconda and create a new environemnt.
 
 ```console
-eval "$(~/miniforge3/bin/conda shell.bash hook)"
+module load anaconda3/personal
+anaconda-setup
 conda create -n Renv r-base=4.1.2 -c conda-forge
 ```
 
-The name after "-n" is a unique name for this environment. Once that completes, other packages can be installed via conda. This environment can then be activated with:
+The anaconda-setup command will only need to be run the first time you load anaconda3/personal. The name after "-n" is a unique name for this environment. Once that completes and other packages can be installed via Anaconda. This environment can then be activated with:
 
 ```console
 source activate Renv
@@ -71,7 +72,7 @@ At the top left of the screen select the tab called Terminal. This will drop the
 First the R environment needs to be loaded, which is done in a similar way to before.
 
 ```console
-eval "$(~/miniforge3/bin/conda shell.bash hook)"
+module load anaconda3/personal
 source activate Renv
 ```
 

--- a/docs/hpc/applications/guides/openondemand.md
+++ b/docs/hpc/applications/guides/openondemand.md
@@ -19,7 +19,7 @@ eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda create -n Renv r-base=4.1.2 -c conda-forge
 ```
 
-The name after "-n" is a unique name for this environment. Once that completes and other packages can be installed via conda. This environment can then be activated with:
+The name after "-n" is a unique name for this environment. Once that completes, other packages can be installed via conda. This environment can then be activated with:
 
 ```console
 source activate Renv

--- a/docs/hpc/applications/guides/openondemand.md
+++ b/docs/hpc/applications/guides/openondemand.md
@@ -10,17 +10,16 @@ We recommend you setup a [Conda](./conda.md) environment when using RStudio; the
 
 ## Creating an Conda Environment
 
-We recommend you familiarise yourself with the use of Conda and R by going to the [R application page](./R.md). You will then need to prepare your Conda environment by first connecting to the login node using SSH (see the [Getting started](../../getting-started/index.md) guide for advice on doing this).
+We recommend you familiarise yourself with the use of Conda and R by going to the [R application page](./R.md). You will then need to prepare your Conda environment by first connecting to the login node using SSH (see the [Getting started](../../getting-started/index.md) guide for advice on doing this) and then install miniforge following the advice on [Conda](./conda.md). Once done you can start creating R environments for OOD.
 
-From there, load Anaconda and create a new environemnt.
+Here we load miniforge and then create an environment called "Renv" with R version 4.1.2:
 
 ```console
-module load anaconda3/personal
-anaconda-setup
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda create -n Renv r-base=4.1.2 -c conda-forge
 ```
 
-The anaconda-setup command will only need to be run the first time you load anaconda3/personal. The name after "-n" is a unique name for this environment. Once that completes and other packages can be installed via Anaconda. This environment can then be activated with:
+The name after "-n" is a unique name for this environment. Once that completes and other packages can be installed via conda. This environment can then be activated with:
 
 ```console
 source activate Renv
@@ -72,7 +71,7 @@ At the top left of the screen select the tab called Terminal. This will drop the
 First the R environment needs to be loaded, which is done in a similar way to before.
 
 ```console
-module load anaconda3/personal
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 source activate Renv
 ```
 

--- a/docs/hpc/applications/guides/python.md
+++ b/docs/hpc/applications/guides/python.md
@@ -65,12 +65,12 @@ cd $PBS_O_WORKDIR
 python3 some_python_script.py
 ```
 
-## Anaconda Python
+## Conda and Python
 
-If you are already familiar with Anaconda Python, this may be your best option in terms of getting your environment (set of python modules) working on the HPC facility. To begin, following the instructions in the [Conda application guide](./conda.md) to setup Conda for your account. Assuming you have done this, the following set of instructions would create an environment called py39 containing python 3.9, and would install numpy in that environment.
+If you are already familiar with package managers like Anaconda, this may be your best option in terms of getting your environment (set of python modules) working on the HPC facility. To begin, following the instructions in the [Conda application guide](./conda.md) to setup Conda for your account. Assuming you have done this, the following set of instructions would create an environment called py39 containing python 3.9, and would install numpy in that environment.
 
 ```console
-module load anaconda3/personal
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda create -n py39 python=3.9
 source activate py39
 (py39) conda search numpy

--- a/docs/hpc/applications/guides/pytorch.md
+++ b/docs/hpc/applications/guides/pytorch.md
@@ -3,12 +3,11 @@
 [PyTorch](https://pytorch.org/) enables fast, flexible experimentation and efficient production through a user-friendly front-end, distributed training, and ecosystem of tools and libraries.
 
 ## Conda
-Whether using  CPU's or GPU's, you should install PyTorch into a clean Anaconda environment. You will need to first setup up your own [Anaconda environment](./conda.md).
+Whether using  CPU's or GPU's, you should install PyTorch into a clean conda environment. You will need to first setup up your own [conda environment](./conda.md).
 
 Please take care when installing PyTorch with other packages. It isn't uncommon for PyTorch to conflict with other packages so we generally recommend keeping your PyTorch environment to a minimum. Also, for users who are interested in having both Pytorch and TensorFlow installed in the same environment, please replace the last line in the code block with the one provided in the TensorFlow and Pytorch section.
 
 ```console
-module load anaconda3/personal
 conda create -n pytorch_env -c conda-forge cudatoolkit=11.8 python=3.11
 conda activate pytorch_env
 conda install -c "nvidia/label/cuda-11.8.0" cuda-nvcc
@@ -40,8 +39,8 @@ You should then be able to test this works in a job, for example:
 #PBS -lwalltime=1:0:0
   
 cd $PBS_O_WORKDIR
-  
-module load anaconda3/personal
+
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 source activate  pytorch_env
   
 ## Verify install:

--- a/docs/hpc/applications/guides/tensorflow.md
+++ b/docs/hpc/applications/guides/tensorflow.md
@@ -2,7 +2,7 @@
 
 [TensorFlow](https://www.tensorflow.org/) is an open source software library for high-performance numerical computation that allows users to create sophisticated deep learning and machine learning applications. The flexible architecture of this library enables you to deploy computation to one or more CPUs or GPUs. TensorFlow also includes [TensorBoard](https://www.tensorflow.org/guide/summaries_and_tensorboard), a data visualization toolkit.
 
-There are a number of methods that can be used to install TensorFlow, such as using pip to install the wheels available on PyPI, or using Anaconda. 
+There are a number of methods that can be used to install TensorFlow, such as using pip to install the wheels available on PyPI, or using conda. 
 
 However, neither are installing the software optimised for the used computing hardware and such might lead to performance penalties. Furthermore, although Tensorflow also works in a CPU mode only, it is not recommended to do so at the performance is inferior compared with a GPU installation.
 

--- a/docs/hpc/applications/guides/tensorflow.md
+++ b/docs/hpc/applications/guides/tensorflow.md
@@ -46,7 +46,7 @@ module av Tensor
 This will display all the currently installed versions of Tensorflow.
 
 ## Conda
-Whether using  CPU's or GPU's, you should install TensorFlow into a clean Anaconda environment. You will need to first setup up your own [Anaconda environment](./conda.md).
+Whether using  CPU's or GPU's, you should install TensorFlow into a clean conda environment. You will need to first setup up your own [conda environment](./conda.md).
 
 Please take care when installing Tensorflow with other packages. It isn't uncommon for Tensorflow to conflict with other packages so we generally recommend keeping your Tensorflow environment to a minimum. 
 
@@ -56,7 +56,6 @@ The example below installs both the CPU and GPU version of Tensorflow. If you do
 
 
 ```console
-module load anaconda3/personal
 conda create -n tf2_env -c conda-forge cudatoolkit=11.8 python=3.11
 source activate tf2_env
 conda install -c "nvidia/label/cuda-11.8.0" cuda-nvcc
@@ -79,7 +78,7 @@ Once the installation has been completed a test job can be submitted to PBS.
  
 cd $PBS_O_WORKDIR
  
-module load anaconda3/personal
+eval "$(~/miniforge3/bin/conda shell.bash hook)"
 source activate tf2_env
  
 ## Verify install:


### PR DESCRIPTION
Due to the changes in the Anaconda ToS we would like to direct users to conda-forge. Anaconda did back track a little from the original changes but it is still possible to see a researcher that has an corporate sponsor as needing a license to use Anaconda. From https://www.anaconda.com/pricing/terms-of-service-faqs

_Anaconda is free for all educational entities—even those with 200 or more employees or contractors—when used in a course curriculum, including teaching, learning, and researching, at accredited universities worldwide. 

A paid license is always required for any individual or entity—even an educational entity—that is embedding, mirroring, or providing third parties access to our products. If you’re interested in pursuing an embedded use case, please contact our partner team at [partnerships@anaconda.com](mailto:partnerships@anaconda.com). See the [Anaconda Terms of Service](https://legal.anaconda.com/policies/en/) for details_