### PR TITLE
Conda channel

### DIFF
--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -83,4 +83,47 @@ channels:
   - bioconda
 ```
 
-As mentioned in the section [Anaconda3/personal](#anaconda3-personal)
+As mentioned in the section [Anaconda3/personal](#anaconda3personal), anaconda recently updated its licensing terms and we cannot use the defaults channel. We need to remove this channel from all our `.condarc` files. For some users who may have installed their own version of conda, they may have the `.condarc` file in multiple locations. They can use the following command to see the location of such files.
+
+```bash
+# Input Command
+conda config --show-sources
+
+# Output of the above command
+==> /rds/general/user/lragta/home/.condarc <==
+auto_activate_base: False
+channel_priority: strict
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+
+```
+
+For most of the users, the file will be in their home directory. To remove the defaults channel, they can use the following command.
+
+```bash
+conda config --remove channels defaults
+```
+
+This will remove the `defaults` channel from your list of channels. To see if `defaults` channel was actually removed, please run this command again.
+
+```bash
+# Input command
+conda config --show channels
+
+# Output
+channels:
+  - conda-forge
+  - bioconda
+```
+
+You should not see the `defaults` channel now as shown above.
+
+If you would like to manually delete/edit the file, you can do so by using your favourite editor such as vim, nano etc. For example, you can use
+
+```bash
+vim /full_path_to_condarc_file
+```
+
+Please delete the `defaults` channel, save your file and exit. Please make sure that you do this for all your `.condarc` files.

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -56,3 +56,31 @@ conda activate /rds/general/user/username/home/anaconda3/envs/tf2_env
 ```
 
 If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchase a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)
+
+## How to disable the default channel
+
+Conda uses a list of channels to download and install packages. Some of the most common channels include `conda-forge`, `bioconda` etc. If you do not specify any channel, it uses the `defaults` channel by default.
+
+The list of channels is usually stored in a file called `.condarc`. `.condarc` is a configuration file used by Conda to store user-defined settings, such as:
+
+* Channels (where Conda looks for packages)
+* Proxy settings
+* Default environments
+* Custom paths
+* Other Conda behaviors
+
+You can see the list of all channels in your `.condarc` file by using the following command
+
+```bash
+conda config --show channels
+```
+
+For example, running in my home directory may give output like
+```bash
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+```
+
+As mentioned in the section [Anaconda3/personal](#anaconda3-personal)

--- a/docs/hpc/applications/guides/conda.md
+++ b/docs/hpc/applications/guides/conda.md
@@ -55,9 +55,9 @@ eval "$(~/miniforge3/bin/conda shell.bash hook)"
 conda activate /rds/general/user/username/home/anaconda3/envs/tf2_env
 ```
 
-If you are still using the old Anaconda3/personal module can we please ask that you disable the "default" channel as this may require the University to purchase a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)
+If you are still using the old Anaconda3/personal module can we please ask that you [Disable the "defaults" channel](#how-to-disable-the-defaults-channel)  as this may require the University to purchase a license for every user. More information on Anaconda's terms of service can be found at: [https://www.anaconda.com/pricing/terms-of-service-faqs](https://www.anaconda.com/pricing/terms-of-service-faqs)
 
-## How to disable the default channel
+## How to disable the defaults channel
 
 Conda uses a list of channels to download and install packages. Some of the most common channels include `conda-forge`, `bioconda` etc. If you do not specify any channel, it uses the `defaults` channel by default.
 


### PR DESCRIPTION
In this PR, we added some details on how user can remove the defaults channel from their conarc files. It will help to ensure that people do not use this channel as mentioned in https://icl-rcs-user-guide.readthedocs.io/en/latest/hpc/applications/guides/conda/.