### PR TITLE
Added details on how to ssh to compute node on CX3 cluster

### DIFF
--- a/docs/hpc/faq/ssh-compute-node.md
+++ b/docs/hpc/faq/ssh-compute-node.md
@@ -1,0 +1,36 @@
+# SSH to a compute node
+
+In some cases, you want to SSH into a compute node to see if your job is running as intended or to debug your code. You can do this by following the steps below.
+
+You would need to know the job ID of your job along with the node name where your job is running. To get the node name, you can use `PBS_NODEFILE` environment variable. You can save the node name to a file by running the following command in your job script:
+
+```bash
+echo $PBS_NODEFILE >> my_nodefile.txt
+```
+
+Once this command runs, you would have something like this in `my_nodefile.txt`:
+
+```bash
+cx3-16-2-2
+```
+
+This is the node name where your job is running. Also, you would have your job ID when you submitted your job. If you do not remember your job ID, you can get it by running the command:
+
+```bash
+qstat -u $USER
+
+#It may return something like this:
+Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
+--------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
+790768.pbs-7    user_name   v1_smal* trial.sh   24405*   1   8   64gb 23:59 R 11:11
+```
+
+Once you have the above information, you can SSH into the compute node by running the following command:
+
+```bash
+export PBS_JOBID=your_job_id #For example 790768
+
+ssh cx3-16-2-2
+```
+
+Once on the compute node, you can check the status of your job or debug your code as needed. You can also use `top` or `htop` to see the processes running on the node.

--- a/docs/hpc/faq/ssh-compute-node.md
+++ b/docs/hpc/faq/ssh-compute-node.md
@@ -1,36 +1,28 @@
 # SSH to a compute node
 
-In some cases, you want to SSH into a compute node to see if your job is running as intended or to debug your code. You can do this by following the steps below.
+In some cases, you may want to SSH into a compute node to see if your job is running as intended or to debug your code. You can do this by following the steps below.
 
-You would need to know the job ID of your job along with the node name where your job is running. To get the node name, you can use `PBS_NODEFILE` environment variable. You can save the node name to a file by running the following command in your job script:
-
-```bash
-echo $PBS_NODEFILE >> my_nodefile.txt
-```
-
-Once this command runs, you would have something like this in `my_nodefile.txt`:
+You would need to know the job ID of your job along with the node name where your job is running. To get these details, you can run the following command:
 
 ```bash
-cx3-16-2-2
+$ qstat -nu $USER -1
+
+# This will give you the output in the following format
+pbs-7: 
+                                                           Req'd  Req'd  Elap
+Job ID          Username  Queue    Jobname    SessID  NDS  TSK   Memory  Time  S Time
+--------------- -------- -------- ---------- ------   ---  ---   ------  ----- - -----
+792950.pbs-7     user   v1_small  trial.sh    36936*   1   8      50gb  18:59 R 16:38 cx3-13-24/3*8
 ```
 
-This is the node name where your job is running. Also, you would have your job ID when you submitted your job. If you do not remember your job ID, you can get it by running the command:
-
-```bash
-qstat -u $USER
-
-#It may return something like this:
-Job ID          Username Queue    Jobname    SessID NDS TSK Memory Time  S Time
---------------- -------- -------- ---------- ------ --- --- ------ ----- - -----
-790768.pbs-7    user_name   v1_smal* trial.sh   24405*   1   8   64gb 23:59 R 11:11
-```
+The last column is the node name where your job is running. In this case, it is `cx3-13-24`. The part after `/` i.e. `3*8` indicates placement of your code in the NUMA domain and can be ignored for now.
 
 Once you have the above information, you can SSH into the compute node by running the following command:
 
 ```bash
-export PBS_JOBID=your_job_id #For example 790768
+$ export PBS_JOBID=your_job_id #For example 792950
 
-ssh cx3-16-2-2
+$ ssh cx3-13-24
 ```
 
 Once on the compute node, you can check the status of your job or debug your code as needed. You can also use `top` or `htop` to see the processes running on the node.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - No such file or directory: hpc/faq/bad-interpreter.md
       - Same or Previous Code not working: hpc/faq/code-not-working.md
       - Not enough slots to run MPI program: hpc/faq/not-enough-slots.md
+      - SSH to a compute node: hpc/faq/ssh-compute-node.md
     - Debugging and Profiling:
       - Overview: hpc/advanced/index.md
       - Thread Pinning: hpc/advanced/thread-pinning.md


### PR DESCRIPTION
In this PR, I have added details on how to ssh to a compute node on the CX3 cluster. 

We often receive such requests from the users on how to do this. It will help us to put the details in our documentation to save our time.