### PR TITLE
Added missing items on the FAQ index page

### DIFF
--- a/docs/hpc/faq/index.md
+++ b/docs/hpc/faq/index.md
@@ -12,3 +12,7 @@ Please note that this page would be under active development for some time as we
 * [Jobs causing issues with the RDS](./job-issues-rds.md)
 * [Bad interpreter: No such file or directory](./bad-interpreter.md)
 * [Same or Previous Code not working](./code-not-working.md)
+* [Not enough slots to run MPI program](./not-enough-slots.md)
+* [SSH to a compute node](./ssh-compute-node.md)
+* [Issues in running multinode Mpi4py program](./multinode-mpi4py.md)
+* [Blas code not running on multi cores](./blas_multicore_issue.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,7 @@ nav:
       - Cannot Create Conda Environment: hpc/faq/cannot-create-conda-env.md
       - How much resource should I ask for: hpc/faq/how-much-resource.md
       - Jobs causing issues with the RDS: hpc/faq/job-issues-rds.md
-      - No such file or directory: hpc/faq/bad-interpreter.md
+      - Bad interpreter, No such file or directory: hpc/faq/bad-interpreter.md
       - Same or Previous Code not working: hpc/faq/code-not-working.md
       - Not enough slots to run MPI program: hpc/faq/not-enough-slots.md
       - SSH to a compute node: hpc/faq/ssh-compute-node.md


### PR DESCRIPTION
1. The index page on the FAQ page was missing a few items which were recently added. This PR addresses that.

2. Also, the title on the `mkdocs.yml` main index page and FAQ page were different for 1 item. The same has been corrected.